### PR TITLE
feat(error): enhance api error by displaying if available the error h…

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -48,11 +48,7 @@ pub struct GeoValue {
 
 impl GeoValue {
     pub fn new(lat: Double, lon: Double, elev: Option<Long>) -> GeoValue {
-        GeoValue {
-            lat,
-            lon,
-            elev,
-        }
+        GeoValue { lat, lon, elev }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use std::{error, fmt, io, result};
 
 #[derive(Debug)]
 pub enum Error {
-    ApiError(Warp10Response),
+    ApiError(Warp10Response, Option<String>),
     HttpError(isahc::http::Error),
     HttpUriError(isahc::http::uri::InvalidUri),
     HttpBodyError(isahc::Error),
@@ -16,7 +16,10 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Error::ApiError(ref resp) => write!(f, "Warp10 API error: {:?}", resp),
+            Error::ApiError(ref resp, Some(ref err)) => {
+                write!(f, "Warp10 API error: {:?}, {}", resp, err)
+            }
+            Error::ApiError(ref resp, None) => write!(f, "Warp10 API error: {:?}", resp),
             Error::HttpError(ref err) => write!(f, "Warp10 HTTP error: {}", err),
             Error::HttpUriError(ref err) => write!(f, "Warp10 HTTP URI error: {}", err),
             Error::HttpBodyError(ref err) => write!(f, "Warp10 HTTP body error: {}", err),
@@ -29,7 +32,7 @@ impl fmt::Display for Error {
 impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
-            Error::ApiError(_) => None,
+            Error::ApiError(_, _) => None,
             Error::HttpError(ref err) => Some(err),
             Error::HttpUriError(ref err) => Some(err),
             Error::HttpBodyError(ref err) => Some(err),
@@ -40,8 +43,8 @@ impl error::Error for Error {
 }
 
 impl Error {
-    pub fn api_error(response: Warp10Response) -> Error {
-        Error::ApiError(response)
+    pub fn api_error(response: Warp10Response, err: Option<String>) -> Error {
+        Error::ApiError(response, err)
     }
 }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,6 +1,6 @@
 use isahc::{
-    http::status::StatusCode, AsyncBody, AsyncReadResponseExt, Body, ReadResponseExt, Request,
-    RequestExt,
+    http::{status::StatusCode, HeaderMap, HeaderValue},
+    AsyncBody, AsyncReadResponseExt, Body, ReadResponseExt, Request, RequestExt,
 };
 
 use crate::client::*;
@@ -20,20 +20,31 @@ impl<'a> Writer<'a> {
         Self { client, token }
     }
 
+    fn extract_header_err(headers: &HeaderMap<HeaderValue>) -> Option<String> {
+        // Extract the error header from the Warp 10 response, the header is defined here
+        // https://github.com/senx/warp10-platform/blob/master/warp10/src/main/java/io/warp10/continuum/store/Constants.java#L155
+        headers
+            .get("X-Warp10-Error-Message")
+            .map(|hv| hv.as_bytes().to_vec())
+            .and_then(|buf| String::from_utf8(buf).ok())
+    }
+
     pub async fn post(&self, data: Vec<Data>) -> Result<Warp10Response> {
         let request = self.post_request::<AsyncBody>(data)?;
         let mut response = request.send_async().await?;
         let status = response.status();
+        let err = Writer::extract_header_err(&response.headers());
         let payload = response.text().await?;
-        self.handle_response(status, payload)
+        self.handle_response(err, status, payload)
     }
 
     pub fn post_sync(&self, data: Vec<Data>) -> Result<Warp10Response> {
         let request = self.post_request::<Body>(data)?;
         let mut response = request.send()?;
         let status = response.status();
+        let err = Writer::extract_header_err(&response.headers());
         let payload = response.text()?;
-        self.handle_response(status, payload)
+        self.handle_response(err, status, payload)
     }
 
     fn post_request<T: From<String>>(&self, data: Vec<Data>) -> Result<Request<T>> {
@@ -53,11 +64,16 @@ impl<'a> Writer<'a> {
         Ok(request)
     }
 
-    fn handle_response(&self, status: StatusCode, payload: String) -> Result<Warp10Response> {
+    fn handle_response(
+        &self,
+        err: Option<String>,
+        status: StatusCode,
+        payload: String,
+    ) -> Result<Warp10Response> {
         let response = Warp10Response::new(status, payload);
         match response.status() {
             StatusCode::OK => Ok(response),
-            _ => Err(Error::api_error(response)),
+            _ => Err(Error::api_error(response, err)),
         }
     }
 }


### PR DESCRIPTION
…eader

* The error message is located in the response header under the name of X-Warp10-Error-Message.
  You can find a reference by following this link:
  https://github.com/senx/warp10-platform/blob/master/warp10/src/main/java/io/warp10/continuum/store/Constants.java#L155

Signed-off-by: Florentin Dubois <florentin.dubois@hey.com>