### PR TITLE
feat(reader): implements read from warp10 via exec endpoint

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,23 +1,30 @@
 use isahc::http::uri::Uri;
 
 use crate::error::*;
+use crate::reader::*;
 use crate::token::*;
 use crate::writer::*;
 
 #[derive(Debug)]
 pub struct Client {
     update_uri: Uri,
+    exec_uri: Uri,
 }
 
 impl Client {
     pub fn new(uri: &str) -> Result<Client> {
         Ok(Client {
             update_uri: format!("{}/api/v0/update", uri).parse()?,
+            exec_uri: format!("{}/api/v0/exec", uri).parse()?,
         })
     }
 
     pub fn update_uri(&self) -> &Uri {
         &self.update_uri
+    }
+
+    pub fn exec_uri(&self) -> &Uri {
+        &self.exec_uri
     }
 
     pub fn host_and_maybe_port(&self) -> String {
@@ -31,5 +38,9 @@ impl Client {
 
     pub fn get_writer(&self, token: String) -> Writer<'_> {
         Writer::new(self, Token::new(self, token))
+    }
+
+    pub fn get_reader(&self, token: String) -> Reader<'_> {
+        Reader::new(self, token)
     }
 }

--- a/src/http_handler.rs
+++ b/src/http_handler.rs
@@ -1,0 +1,23 @@
+use crate::{Error, Warp10Response};
+use isahc::http::{HeaderMap, HeaderValue, StatusCode};
+
+pub(crate) fn extract_header_err(headers: &HeaderMap<HeaderValue>) -> Option<String> {
+    // Extract the error header from the Warp 10 response, the header is defined here
+    // https://github.com/senx/warp10-platform/blob/master/warp10/src/main/java/io/warp10/continuum/store/Constants.java#L155
+    headers
+        .get("X-Warp10-Error-Message")
+        .map(|hv| hv.as_bytes().to_vec())
+        .and_then(|buf| String::from_utf8(buf).ok())
+}
+
+pub(crate) fn handle_response(
+    err: Option<String>,
+    status: StatusCode,
+    payload: String,
+) -> crate::Result<Warp10Response> {
+    let response = Warp10Response::new(status, payload);
+    match response.status() {
+        StatusCode::OK => Ok(response),
+        _ => Err(Error::api_error(response, err)),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 mod client;
 mod data;
 mod error;
+mod http_handler;
+mod reader;
 mod response;
 mod token;
 mod writer;
@@ -8,6 +10,7 @@ mod writer;
 pub use crate::client::*;
 pub use crate::data::*;
 pub use crate::error::*;
+pub use crate::reader::*;
 pub use crate::response::*;
 pub use crate::token::*;
 pub use crate::writer::*;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,0 +1,54 @@
+use isahc::http::header::{CONTENT_TYPE, HOST};
+use isahc::{
+    http::HeaderValue, AsyncBody, AsyncReadResponseExt, Body, ReadResponseExt, Request, RequestExt,
+};
+
+use crate::client::*;
+use crate::error::*;
+use crate::http_handler;
+use crate::response::*;
+
+#[derive(Debug)]
+pub struct Reader<'a> {
+    client: &'a Client,
+    token: String,
+}
+
+impl<'a> Reader<'a> {
+    pub fn new(client: &'a Client, token: String) -> Self {
+        Self { client, token }
+    }
+
+    pub async fn get(&self, warp_script: &str) -> Result<Warp10Response> {
+        let request = self.get_request::<AsyncBody>(warp_script)?;
+        let mut response = request.send_async().await?;
+        let status = response.status();
+        let err = http_handler::extract_header_err(response.headers());
+        let payload = response.text().await?;
+        http_handler::handle_response(err, status, payload)
+    }
+
+    pub fn get_sync(&self, warp_script: &str) -> Result<Warp10Response> {
+        let request = self.get_request::<Body>(warp_script)?;
+        let mut response = request.send()?;
+        let status = response.status();
+        let err = http_handler::extract_header_err(response.headers());
+        let payload = response.text()?;
+        http_handler::handle_response(err, status, payload)
+    }
+
+    fn get_request<T: From<String>>(&self, warp_script: &'a str) -> Result<Request<T>> {
+        let mut request = Request::post(self.client.exec_uri())
+            .body(T::from(warp_script.replace("$TOKEN", &self.token)))?;
+        request.headers_mut().insert(
+            CONTENT_TYPE,
+            HeaderValue::from_str("text/plain; charset=utf-8").expect("failed to parse mime type"),
+        );
+        request.headers_mut().insert(
+            HOST,
+            HeaderValue::from_str(&self.client.host_and_maybe_port())
+                .unwrap_or_else(|_| HeaderValue::from_static("localhost")),
+        );
+        Ok(request)
+    }
+}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,11 +1,9 @@
-use isahc::{
-    http::{status::StatusCode, HeaderMap, HeaderValue},
-    AsyncBody, AsyncReadResponseExt, Body, ReadResponseExt, Request, RequestExt,
-};
+use isahc::{AsyncBody, AsyncReadResponseExt, Body, ReadResponseExt, Request, RequestExt};
 
 use crate::client::*;
 use crate::data::*;
 use crate::error::*;
+use crate::http_handler;
 use crate::response::*;
 use crate::token::*;
 
@@ -20,31 +18,22 @@ impl<'a> Writer<'a> {
         Self { client, token }
     }
 
-    fn extract_header_err(headers: &HeaderMap<HeaderValue>) -> Option<String> {
-        // Extract the error header from the Warp 10 response, the header is defined here
-        // https://github.com/senx/warp10-platform/blob/master/warp10/src/main/java/io/warp10/continuum/store/Constants.java#L155
-        headers
-            .get("X-Warp10-Error-Message")
-            .map(|hv| hv.as_bytes().to_vec())
-            .and_then(|buf| String::from_utf8(buf).ok())
-    }
-
     pub async fn post(&self, data: Vec<Data>) -> Result<Warp10Response> {
         let request = self.post_request::<AsyncBody>(data)?;
         let mut response = request.send_async().await?;
         let status = response.status();
-        let err = Writer::extract_header_err(&response.headers());
+        let err = http_handler::extract_header_err(&response.headers());
         let payload = response.text().await?;
-        self.handle_response(err, status, payload)
+        http_handler::handle_response(err, status, payload)
     }
 
     pub fn post_sync(&self, data: Vec<Data>) -> Result<Warp10Response> {
         let request = self.post_request::<Body>(data)?;
         let mut response = request.send()?;
         let status = response.status();
-        let err = Writer::extract_header_err(&response.headers());
+        let err = http_handler::extract_header_err(&response.headers());
         let payload = response.text()?;
-        self.handle_response(err, status, payload)
+        http_handler::handle_response(err, status, payload)
     }
 
     fn post_request<T: From<String>>(&self, data: Vec<Data>) -> Result<Request<T>> {
@@ -62,18 +51,5 @@ impl<'a> Writer<'a> {
         let mut request = Request::post(self.client.update_uri()).body(T::from(body))?;
         self.token.set_headers(request.headers_mut());
         Ok(request)
-    }
-
-    fn handle_response(
-        &self,
-        err: Option<String>,
-        status: StatusCode,
-        payload: String,
-    ) -> Result<Warp10Response> {
-        let response = Warp10Response::new(status, payload);
-        match response.status() {
-            StatusCode::OK => Ok(response),
-            _ => Err(Error::api_error(response, err)),
-        }
     }
 }


### PR DESCRIPTION
Simple read implementation via exec endpoint which let user handle the response parsing with `Warp10Response` `payload` field